### PR TITLE
Add server code and cleanup docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Copy this file to .env and fill in your API keys
+OPENAI_API_KEY=
+DO_GENAI_API_KEY=
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# TM3Global
+# TM3 Global
+
+This repository contains a minimal demo of the TM3 Flame Sovereign Portal. The project includes a small Flask web app, a Node.js helper service for creating OpenAI realtime sessions and a Python bridge to DigitalOcean's GenAI API.
+
+## Local setup
+
+1. **Install dependencies**
+   ```bash
+   pip install -r requirements.txt
+   npm install express node-fetch dotenv --prefix server
+   ```
+2. **Set environment variables**
+   Create a `.env` file based on `.env.example` and fill in the required API keys.
+3. **Run the Flask app**
+   ```bash
+   python app.py
+   ```
+4. **Run the Node.js service**
+   ```bash
+   node server/index.js
+   ```
+
+## DigitalOcean GenAI
+
+The `genai_inference_bridge.py` script demonstrates how to call DigitalOcean's GenAI API. Set `DO_GENAI_API_KEY` and run:
+
+```bash
+python genai_inference_bridge.py
+```
+
+

--- a/dashboard/realtime.js
+++ b/dashboard/realtime.js
@@ -1,0 +1,22 @@
+async function initRealtime() {
+  const { client_secret: { value: token }} = await fetch("/session").then(r => r.json());
+  const pc = new RTCPeerConnection();
+  const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  pc.addTrack(stream.getTracks()[0]);
+
+  const dc = pc.createDataChannel("oai-events");
+  dc.onmessage = e => handleOAI(JSON.parse(e.data));
+
+  const audio = new Audio();
+  audio.autoplay = true;
+  pc.ontrack = e => (audio.srcObject = e.streams[0]);
+
+  await pc.setLocalDescription(await pc.createOffer());
+  const ans = await fetch(`https://api.openai.com/v1/realtime?model=gpt-4o-realtime-preview-2025-06-03`, {
+    method: "POST",
+    body: pc.localDescription.sdp,
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/sdp" },
+  }).then(r => r.text());
+  await pc.setRemoteDescription({ type: "answer", sdp: ans });
+}
+

--- a/genai_inference_bridge.py
+++ b/genai_inference_bridge.py
@@ -1,12 +1,16 @@
 
 # TM3 GenAI Inference Bridge
-# This script enables seamless serverless AI calls using DigitalOcean GenAI API
+"""Utility for calling the DigitalOcean GenAI API from Python."""
 
-import requests
 import os
+import json
+import requests
 
 DO_GENAI_API_KEY = os.getenv("DO_GENAI_API_KEY")
 GENAI_API_URL = "https://api.digitalocean.com/v2/genai/inference"
+
+if not DO_GENAI_API_KEY:
+    raise EnvironmentError("DO_GENAI_API_KEY is not set")
 
 def infer(prompt, model="gpt-4"):
     headers = {
@@ -24,3 +28,4 @@ if __name__ == "__main__":
     # Example use: Sovereign prompt
     output = infer("Explain flame-based sovereignty and its integration with TM3 systems.")
     print(json.dumps(output, indent=2))
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask==2.3.3
 gunicorn
+requests

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,24 @@
+import express from "express";
+import fetch from "node-fetch";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const app = express();
+
+app.get("/session", async (_, res) => {
+  const r = await fetch("https://api.openai.com/v1/realtime/sessions", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "gpt-4o-realtime-preview-2025-06-03",
+      voice: "verse",
+    }),
+  });
+  res.json(await r.json());
+});
+
+app.listen(4000);


### PR DESCRIPTION
## Summary
- document how to run the Flask app, Node server, and GenAI bridge
- add example `.env`
- include Node server and realtime dashboard script
- fix GenAI bridge imports and add API key validation
- list `requests` in requirements

## Testing
- `python -m py_compile genai_inference_bridge.py app.py`
- `node --check server/index.js`
- `DO_GENAI_API_KEY=dummy python genai_inference_bridge.py`
- `python genai_inference_bridge.py` *(fails: DO_GENAI_API_KEY is not set)*

------
https://chatgpt.com/codex/tasks/task_e_685ec45bda08832c90c7f4426ac6c3c8